### PR TITLE
geopoint format option is available + i18n fallaback supports empty s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `geopointFormat` option is available inside data-schema `formOptions`
+- empty string is supported in i18n label resolution
+
 ## [1.0.12] - 2023-12-04
 
 - i18n objects are resolved to strings using english as fallback language

--- a/src/schemas/data-schema.ts
+++ b/src/schemas/data-schema.ts
@@ -72,6 +72,7 @@ export interface FormOptions {
   placeholder?: LocalizedText
   readOnly?: boolean
   showFileInViewer?: boolean
+  geopointFormat?: ['lat', 'lon'] | ['lon', 'lat']
 }
 
 export interface ExtendedJSONSchema7Definition extends Omit<JSONSchema7, 'type' | 'properties' | 'items' | 'description'> {

--- a/src/utils/__tests__/i18n.test.ts
+++ b/src/utils/__tests__/i18n.test.ts
@@ -19,6 +19,9 @@ describe('i18n tests', () => {
     }],
     ['str', 'es', {
       en: 'str', it: 'abc'
+    }],
+    ['', 'es', {
+      en: '', it: 'abc'
     }]
   ])('should select %s from language %s in object %s', (expected, language, localizedString) => {
     expect(getLocalizedText(localizedString, language)).toStrictEqual(expected)

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -19,7 +19,7 @@ export function getLocalizedText (
     return localizedText[lang.substring(0, 2)]
   }
 
-  if (localizedText[DEFAULT_LANGUAGE]) {
+  if (typeof localizedText[DEFAULT_LANGUAGE] === 'string') {
     return localizedText[DEFAULT_LANGUAGE]
   }
 


### PR DESCRIPTION

- `geopointFormat` option is available inside data-schema `formOptions`
- empty string is supported in i18n label resolution


## Pull Request Type

- [x] Bugfix
- [x] Feature


## PR Checklist

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Relevant CHANGELOG is updated

## Does this PR introduce a breaking change?

- [X] No
